### PR TITLE
Replace deprecated sql-parse with qusql-parse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ pg_parse_parser = ["pg_parse"]
 sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs" }
 pg_query = { git = "https://github.com/pganalyze/pg_query.rs", optional = true }
 pg_parse = { git = "https://github.com/paupino/pg_parse", optional = true }
-sql-parse = { git = "https://github.com/antialize/sql-parse" }
+qusql-parse = "0.3.0"
 polyglot-sql = { git = "https://github.com/tobilg/polyglot" }
 databend-common-ast = "0.2.4"
 orql = { git = "https://codeberg.org/xitep/orql" }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Benchmarking Rust SQL parsers using real-world PostgreSQL statements.
 | **[sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)**                 | 0.61.0  | [`d9b53a0`](https://github.com/sqlparser-rs/sqlparser-rs/commit/d9b53a0cdb369124d9b6ce6237959e66bad859af)   | Pure Rust (multi-dialect)         |
 | **[polyglot-sql](https://github.com/tobilg/polyglot)**                           | 0.1.8   | [`b5e23ec`](https://github.com/tobilg/polyglot/commit/b5e23ec24a053e6a19f4219a82693c8937c50ca8)             | Pure Rust (multi-dialect)         |
 | **[pg_query.rs](https://github.com/pganalyze/pg_query.rs)**                      | 6.1.1   | [`35b8783`](https://github.com/pganalyze/pg_query.rs/commit/35b8783fda79636dd29d787765ca4a0978788f96)       | Rust FFI to C (libpg_query)       |
-| **[sql-parse](https://github.com/antialize/sql-parse)**                          | 0.28.0  | [`ac352f9`](https://github.com/antialize/sql-parse/commit/ac352f97f7ef13ebc44af9295a08095d89882319)         | Pure Rust (zero-copy)             |
+| **[sql-parse](https://github.com/antialize/qusql/)**                          | 0.28.0  | 0.3.0         | Pure Rust (zero-copy)             |
 | **[databend-common-ast](https://github.com/datafuselabs/databend)**              | 0.2.4   | (crates.io release)                                                                                         | Pure Rust (zero-copy, custom)     |
 | **[orql](https://codeberg.org/xitep/orql)**                                      | 0.1.0   | [`c9101ff`](https://codeberg.org/xitep/orql/commit/c9101ffe0efb14ea4c58b761dece532fa62ba9eb)                | Pure Rust (Oracle dialect, early-stage) |
 
@@ -27,7 +27,9 @@ Benchmarking Rust SQL parsers using real-world PostgreSQL statements.
 
 - **pg_query.rs (summary)**: The `pg_query::summary()` function extracts metadata (tables, functions, filter columns, statement types) without deserializing the full AST over protobuf. According to pg_query documentation, this can provide up to an order of magnitude performance improvement over full parsing.
 
-- **sql-parse**: A zero-copy parser using borrowed tokens for minimal allocations. Primarily focused on MySQL/MariaDB with experimental PostgreSQL support.
+- **qusql-parse**: A zero-copy parser using borrowed tokens for minimal allocations. Hand-coded recursive decent parser, with a push down stack for
+faster expression parsing. Focuses primarily on Mysql and PostgreSQL, with some
+support for sqlite.
 
 - **databend-common-ast**: A custom SQL parser built from scratch by the Databend cloud data warehouse team after sqlparser-rs became a performance bottleneck. Uses zero-copy parsing with Pratt expression parsing and logos-based lexing. Supports multiple SQL dialects including a PostgreSQL-compatible mode.
 
@@ -37,17 +39,17 @@ All parsers are configured for PostgreSQL dialect in this benchmark.
 
 ### Project Health & Metrics
 
-| Metric                      | sqlparser-rs        | polyglot-sql    | pg_query.rs     | sql-parse  | databend-common-ast | orql          |
+| Metric                      | sqlparser-rs        | polyglot-sql    | pg_query.rs     | qusql-parse  | databend-common-ast | orql          |
 | --------------------------- | ------------------: | --------------: | --------------: | ---------: | ------------------: | ------------: |
-| **GitHub Stars**            |               3,323 |             615 |             229 |         25 |            9,163    | N/A (Codeberg)|
-| **Total Downloads**         |               50.8M |            <1K  |            1.0M |        53K |                 21K |           <1K |
-| **Recent Downloads** (90d)  |                9.9M |            <1K  |            129K |      1.7K  |               2.6K  |           <1K |
-| **Last Commit**             |            Feb 2026 |        Feb 2026 |        Dec 2025 |   Oct 2025 |            Jan 2026 |      Feb 2026 |
+| **GitHub Stars**            |               3,323 |             615 |             229 |          0 |            9,163    | N/A (Codeberg)|
+| **Total Downloads**         |               50.8M |            <1K  |            1.0M |        918 |                 21K |           <1K |
+| **Recent Downloads** (90d)  |                9.9M |            <1K  |            129K |        918 |                2.6K |           <1K |
+| **Last Commit**             |            Feb 2026 |        Feb 2026 |        Dec 2025 |   Mar 2026 |            Jan 2026 |      Feb 2026 |
 | **First Release**           |            Feb 2018 |        Feb 2026 |        Jan 2022 |   Jan 2022 |            Jun 2024 |      Feb 2026 |
 | **License**                 |          Apache-2.0 |     Apache-2.0  |             MIT | Apache-2.0 |          Apache-2.0 |          0BSD |
 | **Dependencies**            |            0 (core) |        0 (core) | C (libpg_query) |          0 |             0 (core)|             0 |
 | **WASM Support**            |                 Yes |             Yes |              No |        Yes |                  No |       Unknown |
-| **Multi-dialect support**   |                 Yes |  Claims 32 (early-stage; see description) |      PG only    |    MySQL+  |         Yes (4+)    | Oracle only   |
+| **Multi-dialect support**   |                 Yes |  Claims 32 (early-stage; see description) |      PG only    |    Pg,Mysql+  |         Yes (4+)    | Oracle only   |
 | **Maintainer**              | Apache (DataFusion) |      Individual |       pganalyze | Individual |    Databend Labs    |    Individual |
 
 **Key observations:**
@@ -56,7 +58,7 @@ All parsers are configured for PostgreSQL dialect in this benchmark.
 - **polyglot-sql** is brand new (Feb 2026) and still very early-stage. It claims 32-dialect support, but correctness testing shows a ~52–61% false-positive rate, and translation testing reveals widespread silent pass-through failures (22+ constructs not translated, semantic correctness bugs). Treat with caution in any production context.
 - **pg_query.rs** has solid adoption (1M downloads) and is maintained by pganalyze, a company that uses it in production for PostgreSQL query analysis.
 - **databend-common-ast** was purpose-built to overcome sqlparser-rs performance bottlenecks. The crate is extracted from the larger Databend project (8K+ stars).
-- **sql-parse** is a smaller project with limited maintainer bandwidth, primarily targeting MySQL/MariaDB.
+- **qusql-parse** is a smaller project with limited maintainer bandwidth.
 
 ### Correctness Benchmark
 
@@ -131,10 +133,8 @@ Not all parsers successfully parse all statements in the performance benchmark c
 | pg_query.rs           |      100% |   100% |   100% |   100% |
 | pg_query.rs (summary) |      100% |   100% |   100% |   100% |
 | databend-common-ast   |   **99.2%**| **94.3%**| **98.2%**| **97.3%**|
-| sql-parse             | **30.1%** |  97.8% |  95.8% |  95.7% |
+| sql-parse             |      100% |   100% |   100% |   100% |
 | orql                  | **62.3%** |   0.0% |   0.0% |   0.0% |
-
-**⚠️ sql-parse**: Only ~30% of SELECT statements parse successfully - it is primarily a MySQL/MariaDB parser. Speed results for sql-parse SELECT benchmarks reflect only the simpler subset of statements it can handle.
 
 **⚠️ databend-common-ast**: Fails on some PostgreSQL-specific constructs (`RETURNING`, certain type casts, PG-specific syntax). The ~1–6% failure rate is small but reflects its Databend/ClickHouse dialect focus.
 

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -7,7 +7,7 @@ use sql_ast_benchmark::{
     concatenate_statements, load_delete_statements, load_dml_statements, load_insert_statements,
     load_select_statements, load_update_statements,
 };
-use sql_parse::{parse_statements, Issues, ParseOptions, SQLDialect};
+use qusql_parse::{parse_statements, Issues, ParseOptions, SQLDialect};
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 use std::hint::black_box;
@@ -37,8 +37,8 @@ fn bench_polyglot(sql: &str) {
     let _ = black_box(polyglot_parse(sql, DialectType::PostgreSQL));
 }
 
-fn bench_sql_parse(sql: &str) {
-    let options = ParseOptions::new().dialect(SQLDialect::PostgreSQL);
+fn bench_qusql_parse(sql: &str) {
+    let options = ParseOptions::new().dialect(SQLDialect::PostgreSQL).arguments(qusql_parse::SQLArguments::Dollar);
     let mut issues = Issues::new(sql);
     let _ = black_box(parse_statements(sql, &mut issues, &options));
 }
@@ -127,9 +127,9 @@ fn run_benchmark_group(c: &mut Criterion, group_name: &str, statements: &[String
         );
 
         group.bench_with_input(
-            BenchmarkId::new("sql_parse", size),
+            BenchmarkId::new("qusql_parse", size),
             &concatenated,
-            |b, sql| b.iter(|| bench_sql_parse(sql)),
+            |b, sql| b.iter(|| bench_qusql_parse(sql)),
         );
 
         group.bench_with_input(

--- a/src/bin/check_compat.rs
+++ b/src/bin/check_compat.rs
@@ -1,5 +1,5 @@
 use sql_ast_benchmark::{
-    is_valid_databend, is_valid_orql, is_valid_polyglot, is_valid_sql_parse,
+    is_valid_databend, is_valid_orql, is_valid_polyglot, is_valid_qusql_parse,
     load_delete_statements, load_insert_statements, load_select_statements, load_update_statements,
 };
 
@@ -21,11 +21,11 @@ fn main() {
     check_compat("UPDATE", &update, is_valid_polyglot);
     check_compat("DELETE", &delete, is_valid_polyglot);
 
-    println!("\nsql-parse compatibility:");
-    check_compat("SELECT", &select, is_valid_sql_parse);
-    check_compat("INSERT", &insert, is_valid_sql_parse);
-    check_compat("UPDATE", &update, is_valid_sql_parse);
-    check_compat("DELETE", &delete, is_valid_sql_parse);
+    println!("\nqusql-parse compatibility:");
+    check_compat("SELECT", &select, is_valid_qusql_parse);
+    check_compat("INSERT", &insert, is_valid_qusql_parse);
+    check_compat("UPDATE", &update, is_valid_qusql_parse);
+    check_compat("DELETE", &delete, is_valid_qusql_parse);
 
     println!("\ndatabend compatibility:");
     check_compat("SELECT", &select, is_valid_databend);

--- a/src/bin/correctness.rs
+++ b/src/bin/correctness.rs
@@ -29,7 +29,7 @@
 ///   cargo run --bin scrape_tests
 #[cfg(feature = "pg_query_parser")]
 use sql_ast_benchmark::{
-    databend_roundtrip, is_valid_databend, is_valid_orql, is_valid_polyglot, is_valid_sql_parse,
+    databend_roundtrip, is_valid_databend, is_valid_orql, is_valid_polyglot, is_valid_qusql_parse,
     is_valid_sqlparser, polyglot_roundtrip, sqlparser_roundtrip,
 };
 #[cfg(feature = "pg_query_parser")]
@@ -72,7 +72,7 @@ struct Counts {
     sqlparser: ParserCounts,
     polyglot: ParserCounts,
     databend: ParserCounts,
-    sql_parse: ParserCounts,
+    qusql_parse: ParserCounts,
     orql: ParserCounts,
     #[cfg(feature = "pg_query_parser")]
     pg_query_summary: ParserCounts,
@@ -158,7 +158,7 @@ fn check_file(path: &Path) -> Option<Counts> {
             |s| databend_fidelity(s),
             &valid,
         ),
-        sql_parse: count_for(|s| is_valid_sql_parse(s), &valid, &invalid),
+        qusql_parse: count_for(|s| is_valid_qusql_parse(s), &valid, &invalid),
         orql: count_for(|s| is_valid_orql(s), &valid, &invalid),
         pg_query_summary: count_for(|s| is_valid_pg_query_summary(s), &valid, &invalid),
     })
@@ -271,7 +271,7 @@ fn print_section(label: &str, c: &Counts) {
     print_recall_row("sqlparser-rs", c.sqlparser.accepted, c.valid_total);
     print_recall_row("polyglot-sql", c.polyglot.accepted, c.valid_total);
     print_recall_row("databend-common-ast", c.databend.accepted, c.valid_total);
-    print_recall_row("sql-parse", c.sql_parse.accepted, c.valid_total);
+    print_recall_row("qusql-parse", c.qusql_parse.accepted, c.valid_total);
     print_recall_row("orql", c.orql.accepted, c.valid_total);
 
     // ── False positives ───────────────────────────────────────────────────────
@@ -287,7 +287,7 @@ fn print_section(label: &str, c: &Counts) {
         print_fp_row("sqlparser-rs", &c.sqlparser, c.invalid_total);
         print_fp_row("polyglot-sql", &c.polyglot, c.invalid_total);
         print_fp_row("databend-common-ast", &c.databend, c.invalid_total);
-        print_fp_row("sql-parse", &c.sql_parse, c.invalid_total);
+        print_fp_row("qusql-parse", &c.qusql_parse, c.invalid_total);
         print_fp_row("orql", &c.orql, c.invalid_total);
     }
 
@@ -312,7 +312,7 @@ fn print_section(label: &str, c: &Counts) {
     print_rt_row("sqlparser-rs", &c.sqlparser);
     print_rt_row("polyglot-sql", &c.polyglot);
     print_rt_row("databend-common-ast", &c.databend);
-    println!("│  {:<24}  {:>38}", "sql-parse", "N/A (no pretty-printer)");
+    println!("│  {:<24}  {:>38}", "qusql-parse", "N/A (no pretty-printer)");
     println!("│  {:<24}  {:>38}", "orql", "N/A (no pretty-printer)");
 
     // ── Fidelity ──────────────────────────────────────────────────────────────
@@ -330,7 +330,7 @@ fn print_section(label: &str, c: &Counts) {
     print_fidelity_row("sqlparser-rs", &c.sqlparser);
     print_fidelity_row("polyglot-sql", &c.polyglot);
     print_fidelity_row("databend-common-ast", &c.databend);
-    println!("│  {:<24}  {:>38}", "sql-parse", "N/A (no pretty-printer)");
+    println!("│  {:<24}  {:>38}", "qusql-parse", "N/A (no pretty-printer)");
     println!(
         "│  {:<24}  {:>38}",
         "orql", "N/A (Oracle dialect, no deparse)"

--- a/src/bin/plot.rs
+++ b/src/bin/plot.rs
@@ -32,7 +32,7 @@ const PARSERS: [(&str, &str, RGBColor); 6] = [
         "pg_query.rs (summary)",
         PANTONE_ROSE_QUARTZ,
     ),
-    ("sql_parse", "sql-parse", PANTONE_ULTRA_VIOLET),
+    ("qusql_parse", "qusql-parse", PANTONE_ULTRA_VIOLET),
     ("databend", "databend-common-ast", PANTONE_EMERALD),
 ];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,13 @@ use databend_common_ast::parser::{
 };
 use orql::parser as orql_parser;
 use polyglot_sql::{parse as polyglot_parse, DialectType, Generator as PolyglotGenerator};
-use sql_parse::{parse_statements, Issues, Level, ParseOptions, SQLDialect};
+use qusql_parse::{Issues, Level, ParseOptions, SQLDialect, parse_statements};
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 use std::path::Path;
 
-fn sql_parse_options() -> ParseOptions {
-    ParseOptions::new().dialect(SQLDialect::PostgreSQL)
+fn qusql_parse_options() -> ParseOptions {
+    ParseOptions::new().dialect(SQLDialect::PostgreSQL).arguments(qusql_parse::SQLArguments::Dollar)
 }
 
 // Dataset files
@@ -44,15 +44,10 @@ pub fn is_valid_polyglot(sql: &str) -> bool {
 }
 
 #[must_use]
-pub fn is_valid_sql_parse(sql: &str) -> bool {
-    // sql-parse uses todo!() in some unimplemented paths (e.g. hex literals);
-    // catch_unwind treats those as parse failures.
-    std::panic::catch_unwind(|| {
-        let mut issues = Issues::new(sql);
-        let _ = parse_statements(sql, &mut issues, &sql_parse_options());
-        !issues.get().iter().any(|i| i.level == Level::Error)
-    })
-    .unwrap_or(false)
+pub fn is_valid_qusql_parse(sql: &str) -> bool {
+    let mut issues = Issues::new(sql);
+    let _ = parse_statements(&sql, &mut issues, &qusql_parse_options());
+    !issues.get().iter().any(|i| i.level == Level::Error)
 }
 
 #[cfg(feature = "pg_parse_parser")]


### PR DESCRIPTION
sql-parse has been renamed to qusql-parse. 

We have work on better coverage on postgres and mysql, so the coverage should be a lot better.
The main issue causing the so few selects statements to parse was that `parse_statements` would only parse statements
ending in ;. We have used `parse_statement` for single statements. We have fixed `parse_statements` to not require ; in the last statement. After this fix we had ~40 failures in the coverage tests. We analyzed those issues and found ~5 missing features that needed to be implemented.

We now only fail on the statement
```sql
SELECT AVG(word_count) OVER (PARTITION BY EXTRACT(YEAR_QUARTER FROM publish_date)) AS avg_word_count FROM articles WHERE category = 'social_justice' AND location = 'USA' AND YEAR(publish_date) BETWEEN 2021 AND 2022
```
However this is a failure in the test set as `YEAR_QUARTER` is not a valid argument to `EXTRACT`.

Compared to the previous berchmark. We have run our own profiling and found a number of inefficients in the lexer and in the size differences of our AST enum members. I expect that we will now be significantly faster.

I have obviously not updated the benchmark results as I do not have access to whatever hardware the benchmarks where run on.

