### PR TITLE
Add cargo audit security gate in CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,25 @@
+# Configuration for cargo audit (https://github.com/rustsec/rustsec).
+#
+# Every ignored advisory below comes from optional tooling or the historical
+# parser versions the benchmark deliberately compiles, never from the core
+# library or anything in the published site. A new advisory anywhere else still
+# fails the build. Unmaintained-crate warnings (yaml-rust via syntect, bincode,
+# proc-macro-error) are left visible on purpose, they are informational and do
+# not fail the run.
+[advisories]
+ignore = [
+    # fast-float 0.2.0: segfault (no upstream fix) and soundness issues. Pulled
+    # only by the historical databend-common-ast 0.0.3 that the time-machine
+    # crate compiles to benchmark old releases. Current databend uses the
+    # maintained fast-float2 fork, so this never reaches the core benchmark.
+    "RUSTSEC-2025-0003",
+    "RUSTSEC-2024-0379",
+    # rustls-webpki 0.101.7: three certificate-validation advisories, fixed only
+    # in a rustls line that tiberius 0.12.3 does not yet allow. Pulled only by
+    # tiberius (the SQL Server client) in the oracle crate, which runs locally
+    # in Docker to refresh the committed validity labels. It is not part of the
+    # benchmark, the site, or CI, and it talks only to a trusted local container.
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,27 @@
+name: Security audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so newly published advisories are caught without a code change.
+    - cron: "0 6 * * 1"
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      # Cargo.lock is gitignored (the benchmark tracks latest deps), so resolve
+      # a fresh lockfile to audit the versions CI would actually build.
+      - name: Generate lockfile
+        run: cargo generate-lockfile
+      - name: Audit dependencies
+        run: cargo audit


### PR DESCRIPTION
Adds a Security audit workflow that runs cargo audit on push, on pull requests, and weekly so newly published advisories are caught without a code change. Because Cargo.lock is gitignored, the job resolves a fresh lockfile first and audits the versions CI would actually build.

An audit.toml ignores five advisories that come only from optional tooling, never the core library or the published site: fast-float 0.2.0 (pulled by the historical databend-common-ast 0.0.3 that the time machine compiles to benchmark old releases) and rustls-webpki 0.101.7 (pulled by tiberius in the Docker-only oracle crate, which talks to a trusted local container). Each is documented with its source and rationale, and the gate still fails on any new advisory elsewhere. Unmaintained-crate warnings are left visible but non-blocking.