### PR TITLE
Give each parser and dialect a distinct chart marker

### DIFF
--- a/viz/src/chart.rs
+++ b/viz/src/chart.rs
@@ -13,11 +13,38 @@
 )]
 
 use crate::color::parser_rgb;
+use crate::marker::{marker_for, Marker};
 use crate::schema::{DialectData, ParserMetrics, ParserPerf};
 use plotters::prelude::*;
 use plotters::style::RGBColor;
 
 type Res = Result<(), Box<dyn std::error::Error>>;
+
+/// Radius in pixels of the per-series glyphs drawn on curves and in legends.
+const MARKER_R: i32 = 4;
+
+/// Draw a filled marker glyph at a data point on a chart. Generic over the
+/// coordinate system so the same call serves the linear and log-scaled charts.
+/// The glyph's vertices are pixel offsets from the anchor, composed onto an
+/// [`EmptyElement`] at the data coordinate, so size stays constant regardless of
+/// the axis scale.
+fn draw_marker<DB, CT>(
+    chart: &mut ChartContext<DB, CT>,
+    marker: Marker,
+    x: f64,
+    y: f64,
+    color: RGBColor,
+) -> Res
+where
+    DB: DrawingBackend,
+    DB::ErrorType: std::error::Error + 'static,
+    CT: plotters::coord::CoordTranslate<From = (f64, f64)>,
+{
+    chart.draw_series(std::iter::once(
+        EmptyElement::at((x, y)) + Polygon::new(marker.vertices(MARKER_R), color.filled()),
+    ))?;
+    Ok(())
+}
 
 /// Pixels reserved on the right of each chart for the legend, sized to the
 /// widest label so short-label charts (e.g. a single-dialect parser page) do
@@ -80,6 +107,13 @@ where
             vec![(6, y + 6), (30, y + 6)],
             rgb(l.rgb).stroke_width(3),
         ))?;
+        // Marker glyph centered on the swatch so the legend matches the curve.
+        let verts: Vec<(i32, i32)> = marker_for(&l.label)
+            .vertices(MARKER_R)
+            .into_iter()
+            .map(|(dx, dy)| (18 + dx, y + 6 + dy))
+            .collect();
+        area.draw(&Polygon::new(verts, rgb(l.rgb).filled()))?;
         area.draw(&Text::new(
             l.label.clone(),
             (34, y),
@@ -139,6 +173,23 @@ pub fn ecdf_lines(title: &str, lines: &[Line], w: u32, h: u32, x_desc: &str) -> 
                     l.ecdf.iter().map(|pt| (pt[0], pt[1])),
                     rgb(l.rgb).stroke_width(2),
                 ))?;
+                // A handful of glyphs along each curve so series stay
+                // distinguishable without relying on color. Sampling (rather than
+                // one per eCDF point) keeps the curves readable.
+                let m = marker_for(&l.label);
+                let n = l.ecdf.len();
+                if n > 0 {
+                    let count = 6.min(n);
+                    for k in 0..count {
+                        let idx = if count == 1 {
+                            n / 2
+                        } else {
+                            k * (n - 1) / (count - 1)
+                        };
+                        let pt = l.ecdf[idx];
+                        draw_marker(&mut chart, m, pt[0], pt[1], rgb(l.rgb))?;
+                    }
+                }
             }
             draw_legend(&legend, lines)?;
             root.present()?;
@@ -216,6 +267,9 @@ pub fn box_lines(title: &str, lines: &[Line], w: u32, h: u32, y_desc: &str) -> S
                         c.stroke_width(1),
                     )))?;
                 }
+                // Glyph on the median so each box maps to its legend entry
+                // without relying on color or box order.
+                draw_marker(&mut chart, marker_for(&l.label), x, l.median, c)?;
             }
             draw_legend(&legend, lines)?;
             root.present()?;
@@ -454,7 +508,8 @@ pub fn trend_lines(title: &str, series: &[TrendSeries], w: u32, h: u32, y_desc: 
                     s.points.iter().map(|&(x, m, _, _)| (x, m)),
                     rgb(s.rgb).stroke_width(2),
                 ))?;
-                // Interquartile bar and a marker at each release.
+                // Interquartile bar and a per-series glyph at each release.
+                let m = marker_for(&s.label);
                 for &(x, median, p25, p75) in &s.points {
                     let lo = p25.max(ylo);
                     let hi = p75.max(lo);
@@ -462,11 +517,7 @@ pub fn trend_lines(title: &str, series: &[TrendSeries], w: u32, h: u32, y_desc: 
                         vec![(x, lo), (x, hi)],
                         rgb(s.rgb).mix(0.5).stroke_width(1),
                     )))?;
-                    chart.draw_series(std::iter::once(Circle::new(
-                        (x, median),
-                        3,
-                        rgb(s.rgb).filled(),
-                    )))?;
+                    draw_marker(&mut chart, m, x, median, rgb(s.rgb))?;
                 }
             }
             draw_legend(&legend_area, &legend)?;
@@ -555,12 +606,9 @@ pub fn pct_trend_lines(
                     s.points.iter().map(|&(x, v, _, _)| (x, v)),
                     rgb(s.rgb).stroke_width(2),
                 ))?;
+                let m = marker_for(&s.label);
                 for &(x, v, _, _) in &s.points {
-                    chart.draw_series(std::iter::once(Circle::new(
-                        (x, v),
-                        3,
-                        rgb(s.rgb).filled(),
-                    )))?;
+                    draw_marker(&mut chart, m, x, v, rgb(s.rgb))?;
                 }
             }
             draw_legend(&legend_area, &legend)?;

--- a/viz/src/lib.rs
+++ b/viz/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod chart;
 pub mod color;
+pub mod marker;
 pub mod schema;
 
 pub use chart::{
@@ -16,6 +17,7 @@ pub use chart::{
     Line, TrendSeries,
 };
 pub use color::{parser_hex, parser_rgb};
+pub use marker::{marker_for, Marker};
 pub use schema::{
     Bundle, CoverageFile, CoverageMatrix, DepthReport, DepthScan, DialectData, DialectRun,
     FamilyHistory, FeatureCounts, FeatureScan, LintPolicy, MemDist, ParserBatch, ParserFailures,

--- a/viz/src/marker.rs
+++ b/viz/src/marker.rs
@@ -1,0 +1,224 @@
+//! Per-series marker shapes, shared by the SVG charts and the HTML legends so
+//! they match. Color alone does not survive a grayscale print or a red-green
+//! color-vision deficiency, so every parser and every dialect is also assigned a
+//! distinct, stable glyph (triangle, square, diamond, ...). The glyph is keyed by
+//! the same label the color is keyed by ([`crate::color::parser_rgb`] for parsers,
+//! the dialect display name for dialects), so a series keeps one shape across all
+//! charts and its legend entry.
+
+/// A small filled glyph drawn at a data point. Every variant is rendered as a
+/// single polygon (concave ones included) so one drawing path serves them all.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Marker {
+    Circle,
+    Square,
+    TriangleUp,
+    TriangleDown,
+    Diamond,
+    Pentagon,
+    Hexagon,
+    TriangleLeft,
+    TriangleRight,
+    Star,
+    Plus,
+    Cross,
+}
+
+/// The rotation-cycle of shapes used both for the explicit assignments below and
+/// for the deterministic fallback, ordered so adjacent entries look distinct.
+const CYCLE: [Marker; 12] = [
+    Marker::Circle,
+    Marker::Square,
+    Marker::TriangleUp,
+    Marker::Diamond,
+    Marker::TriangleDown,
+    Marker::Pentagon,
+    Marker::Cross,
+    Marker::Hexagon,
+    Marker::TriangleLeft,
+    Marker::Star,
+    Marker::TriangleRight,
+    Marker::Plus,
+];
+
+/// Stable marker for a series by its label. Known parsers and dialect display
+/// names get an explicit, mutually distinct glyph; anything else falls back to a
+/// deterministic hash over the label so unknown series still get a stable shape.
+#[must_use]
+pub fn marker_for(name: &str) -> Marker {
+    match name {
+        // Parsers (same keys as `parser_rgb`).
+        "sqlparser-rs" => Marker::Circle,
+        "pg_query.rs" => Marker::Square,
+        "pg_query (summary)" => Marker::Plus,
+        "polyglot-sql" => Marker::TriangleUp,
+        "qusql-parse" => Marker::Diamond,
+        "databend-common-ast" => Marker::TriangleDown,
+        "sqlglot-rust" => Marker::Pentagon,
+        "sqlite3-parser" => Marker::Hexagon,
+        "turso_parser" => Marker::Star,
+        "orql" => Marker::Cross,
+
+        // Dialects (display names, as carried in the chart series label).
+        "PostgreSQL" => Marker::Circle,
+        "SQLite" => Marker::Square,
+        "MySQL" => Marker::TriangleUp,
+        "ClickHouse" => Marker::Diamond,
+        "DuckDB" => Marker::TriangleDown,
+        "Hive" => Marker::Pentagon,
+        "Spark SQL" => Marker::Hexagon,
+        "Trino" => Marker::TriangleLeft,
+        "T-SQL" => Marker::Star,
+        "Oracle" => Marker::Cross,
+        "BigQuery" => Marker::TriangleRight,
+        "Redshift" => Marker::Plus,
+
+        _ => CYCLE[(fnv1a(name) % CYCLE.len() as u64) as usize],
+    }
+}
+
+/// FNV-1a hash, used only to spread unknown labels across the shape cycle.
+fn fnv1a(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+impl Marker {
+    /// Polygon vertices as integer pixel offsets from the marker center, for a
+    /// glyph of radius `r`. plotters' backend has y increasing downward, so an
+    /// "up" apex is at `-r`. Returned points wind once around the outline.
+    #[must_use]
+    pub fn vertices(self, r: i32) -> Vec<(i32, i32)> {
+        use std::f64::consts::PI;
+        let rf = f64::from(r);
+        // A regular n-gon with its first vertex at angle `rot` (radians).
+        let poly = |n: i32, rot: f64| -> Vec<(i32, i32)> {
+            (0..n)
+                .map(|i| {
+                    let a = rot + f64::from(i) * 2.0 * PI / f64::from(n);
+                    ((rf * a.cos()).round() as i32, (rf * a.sin()).round() as i32)
+                })
+                .collect()
+        };
+        // A k-pointed star alternating outer radius `rf` and inner `rf * inner`.
+        let star = |k: i32, inner: f64, rot: f64| -> Vec<(i32, i32)> {
+            (0..k * 2)
+                .map(|i| {
+                    let rad = if i % 2 == 0 { rf } else { rf * inner };
+                    let a = rot + f64::from(i) * PI / f64::from(k);
+                    (
+                        (rad * a.cos()).round() as i32,
+                        (rad * a.sin()).round() as i32,
+                    )
+                })
+                .collect()
+        };
+        // A plus sign with arm half-width `a` reaching out to `r`.
+        let plus = |rot: f64| -> Vec<(i32, i32)> {
+            let a = (rf * 0.42).round();
+            let base = [
+                (-a, -rf),
+                (a, -rf),
+                (a, -a),
+                (rf, -a),
+                (rf, a),
+                (a, a),
+                (a, rf),
+                (-a, rf),
+                (-a, a),
+                (-rf, a),
+                (-rf, -a),
+                (-a, -a),
+            ];
+            base.iter()
+                .map(|&(x, y)| {
+                    let (c, s) = (rot.cos(), rot.sin());
+                    (
+                        (x * c - y * s).round() as i32,
+                        (x * s + y * c).round() as i32,
+                    )
+                })
+                .collect()
+        };
+        match self {
+            Marker::Circle => poly(12, 0.0),
+            Marker::Square => poly(4, -PI / 4.0),
+            Marker::Diamond => poly(4, -PI / 2.0),
+            Marker::TriangleUp => poly(3, -PI / 2.0),
+            Marker::TriangleDown => poly(3, PI / 2.0),
+            Marker::TriangleLeft => poly(3, PI),
+            Marker::TriangleRight => poly(3, 0.0),
+            Marker::Pentagon => poly(5, -PI / 2.0),
+            Marker::Hexagon => poly(6, -PI / 2.0),
+            Marker::Star => star(5, 0.42, -PI / 2.0),
+            Marker::Plus => plus(0.0),
+            Marker::Cross => plus(PI / 4.0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{marker_for, Marker, CYCLE};
+
+    #[test]
+    fn known_parsers_and_dialects_have_distinct_markers() {
+        let parsers = [
+            "sqlparser-rs",
+            "pg_query.rs",
+            "pg_query (summary)",
+            "polyglot-sql",
+            "qusql-parse",
+            "databend-common-ast",
+            "sqlglot-rust",
+            "sqlite3-parser",
+            "turso_parser",
+            "orql",
+        ];
+        let mut seen: Vec<Marker> = parsers.iter().map(|p| marker_for(p)).collect();
+        let n = seen.len();
+        seen.sort_by_key(|m| format!("{m:?}"));
+        seen.dedup();
+        assert_eq!(seen.len(), n, "parser markers must be mutually distinct");
+
+        let dialects = [
+            "PostgreSQL",
+            "SQLite",
+            "MySQL",
+            "ClickHouse",
+            "DuckDB",
+            "Hive",
+            "Spark SQL",
+            "Trino",
+            "T-SQL",
+            "Oracle",
+            "BigQuery",
+            "Redshift",
+        ];
+        let mut seen: Vec<Marker> = dialects.iter().map(|d| marker_for(d)).collect();
+        let n = seen.len();
+        seen.sort_by_key(|m| format!("{m:?}"));
+        seen.dedup();
+        assert_eq!(seen.len(), n, "dialect markers must be mutually distinct");
+    }
+
+    #[test]
+    fn unknown_label_is_stable_and_in_cycle() {
+        let a = marker_for("some-future-parser");
+        let b = marker_for("some-future-parser");
+        assert_eq!(a, b, "fallback must be deterministic");
+        assert!(CYCLE.contains(&a));
+    }
+
+    #[test]
+    fn vertices_are_nonempty_and_finite() {
+        for m in CYCLE {
+            let v = m.vertices(4);
+            assert!(v.len() >= 3, "{m:?} needs at least 3 vertices");
+        }
+    }
+}


### PR DESCRIPTION
Charts previously distinguished series by color alone, which does not survive grayscale printing or red-green color-vision deficiency. This adds a stable per-series marker glyph (circle, square, triangle, diamond, and so on) keyed by the same label the color is keyed by, so every parser and every dialect keeps one shape across all charts and its legend entry.

A new `viz::marker` module defines the `Marker` enum and `marker_for`, with explicit, mutually distinct assignments for the known parsers and dialects plus a deterministic FNV-1a fallback. In `viz::chart` a generic `draw_marker` helper places constant-pixel-size glyphs on the eCDF curves (sampled), on each box plot median, and at each release point of the trend charts (replacing the old plain `Circle`), and the legend swatch now carries the matching glyph. Glyphs render as single filled polygons. No call sites changed since the marker derives from the series label, and charts render client-side so no data artifacts needed regenerating.